### PR TITLE
Fix a broken link for "Observatoire de la viticulture française".

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Area of the French wine cepages per year.
 
 ## Data
 
-Data is extracted from the [Observatoire de la viticulture française](http://www.observatoire-viti-france.com) maintained by FranceAgriMer.
+Data is extracted from the [Observatoire de la viticulture française](https://www.franceagrimer.fr/Eclairer/Outils/Observatoires/Observatoire-de-la-viticulture-francaise) maintained by FranceAgriMer.
 
 The data is provided as CSV.
 


### PR DESCRIPTION
# Motivation
The link for "Observatoire de la viticulture française" needs updated because current one is broken.

# Change
Change the link from [http://www.observatoire-viti-france.com](http://www.observatoire-viti-france.com) to [https://www.franceagrimer.fr/Eclairer/Outils/Observatoires/Observatoire-de-la-viticulture-francaise](https://www.franceagrimer.fr/Eclairer/Outils/Observatoires/Observatoire-de-la-viticulture-francaise).
